### PR TITLE
Allow configurable reservations file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ python app.py
 
 L'application sera alors disponible sur [http://localhost:5000](http://localhost:5000).
 
+## Configuration
+
+Le chemin du fichier stockant les réservations peut être personnalisé via la variable d'environnement `RESERVATIONS_FILE`.
+Si elle n'est pas définie, l'application utilisera `reservations.json` par défaut.
+
 ## Déploiement
 
 Pour déployer sur une plateforme compatible avec les fichiers `Procfile` (comme Heroku), renommez `Procfile.txt` en `Procfile` si nécessaire puis poussez le dépôt. Le contenu du `Procfile` indique à la plateforme de démarrer l'application avec :

--- a/app.py
+++ b/app.py
@@ -2,11 +2,14 @@
 from flask import Flask, request, jsonify, render_template
 import json
 import logging
+import os
 
 logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
-DATA_FILE = "reservations.json"
+# Allow overriding the reservations storage path via an environment variable
+# Default to 'reservations.json' if not set
+DATA_FILE = os.getenv("RESERVATIONS_FILE", "reservations.json")
 
 @app.route("/")
 def index():


### PR DESCRIPTION
## Summary
- add `RESERVATIONS_FILE` environment variable support in `app.py`
- document `RESERVATIONS_FILE` usage in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff70b978883248223f7ed3a22ad1a