### PR TITLE
Make admin code configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ L'application sera alors disponible sur [http://localhost:5000](http://localhost
 Le chemin du fichier stockant les réservations peut être personnalisé via la variable d'environnement `RESERVATIONS_FILE`.
 Si elle n'est pas définie, l'application utilisera `reservations.json` par défaut.
 
+La valeur du code administrateur peut également être ajustée grâce à la variable d'environnement `ADMIN_CODE`. Elle vaut `s0r1` si elle n'est pas spécifiée.
+
 ## Déploiement
 
 Pour déployer sur une plateforme compatible avec les fichiers `Procfile` (comme Heroku), renommez `Procfile.txt` en `Procfile` si nécessaire puis poussez le dépôt. Le contenu du `Procfile` indique à la plateforme de démarrer l'application avec :

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ app = Flask(__name__, template_folder="templates", static_folder="static")
 # Allow overriding the reservations storage path via an environment variable
 # Default to 'reservations.json' if not set
 DATA_FILE = os.getenv("RESERVATIONS_FILE", "reservations.json")
-ADMIN_CODE = "s0r1"
+ADMIN_CODE = os.getenv("ADMIN_CODE", "s0r1")
 CODE_REGEX = re.compile(r"^\d{4}$")
 
 @app.route("/")

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
         </select>
 
         <label>Code (4 chiffres)</label>
-        <input type="text" id="code" pattern="\d{4}|s0r1" required>
+        <input type="text" id="code" pattern="\d{4}" required>
 
         <button type="submit">Réserver</button>
     </form>


### PR DESCRIPTION
## Summary
- allow overriding `ADMIN_CODE` with an environment variable
- simplify code input pattern in the UI
- document the `ADMIN_CODE` setting

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684007858d14832484f9f367e6edd203