### PR TITLE
Prevent overlapping reservations

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+from datetime import datetime
 from filelock import FileLock
 
 logging.basicConfig(level=logging.INFO)
@@ -48,8 +49,15 @@ def reserver():
     end_hour = int(data['heure'].split(":")[0]) + int(data['tournees'])
     end = f"{data['date']}T{str(end_hour).zfill(2)}:00"
 
+    new_start = datetime.fromisoformat(start)
+    new_end = datetime.fromisoformat(end)
+
     for r in reservations:
-        if r["machine"] == data["machine"] and r["start"] == start:
+        if r["machine"] != data["machine"]:
+            continue
+        existing_start = datetime.fromisoformat(r["start"])
+        existing_end = datetime.fromisoformat(r["end"])
+        if new_start < existing_end and new_end > existing_start:
             return jsonify({"status": "error", "message": "❌ Ce créneau est déjà réservé pour cette machine."}), 409
 
     total_journalier = sum(

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -93,3 +93,30 @@ def test_admin_can_delete_any_reservation(client):
     assert delete.status_code == 200
     assert delete.get_json()["status"] == "deleted"
     assert load_reservations() == []
+
+
+def test_overlapping_reservation_rejected(client):
+    first = {
+        "code": "1234",
+        "date": "2025-01-03",
+        "heure": "12:00",
+        "tournees": 2,
+        "machine": "lave-linge",
+        "chambre": "1",
+    }
+    second = {
+        "code": "5678",
+        "date": "2025-01-03",
+        "heure": "13:00",
+        "tournees": 1,
+        "machine": "lave-linge",
+        "chambre": "2",
+    }
+
+    resp1 = client.post("/reserver", json=first)
+    assert resp1.status_code == 200
+    resp2 = client.post("/reserver", json=second)
+    assert resp2.status_code == 409
+    assert "déjà réservé" in resp2.get_json()["message"]
+    reservations = load_reservations()
+    assert len(reservations) == 1


### PR DESCRIPTION
## Summary
- check for overlapping reservations when booking
- add unit test for overlapping range rejection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684012620e848324818c026c81cceda2