### PR TITLE
Remove code from reservation API

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,11 @@ def reserver():
 @app.route("/get_reservations", methods=["GET"])
 def get_reservations():
     reservations = load_reservations()
-    return jsonify(reservations)
+    sanitized = [
+        {k: v for k, v in r.items() if k != "code"}
+        for r in reservations
+    ]
+    return jsonify(sanitized)
 
 @app.route("/delete_reservation", methods=["POST"])
 def delete_reservation():

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -120,3 +120,23 @@ def test_overlapping_reservation_rejected(client):
     assert "déjà réservé" in resp2.get_json()["message"]
     reservations = load_reservations()
     assert len(reservations) == 1
+
+
+def test_get_reservations_hides_code(client):
+    payload = {
+        "code": "1234",
+        "date": "2025-01-04",
+        "heure": "15:00",
+        "tournees": 1,
+        "machine": "lave-linge",
+        "chambre": "3",
+    }
+    resp = client.post("/reserver", json=payload)
+    assert resp.status_code == 200
+
+    resp = client.get("/get_reservations")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert data
+    assert "code" not in data[0]


### PR DESCRIPTION
## Summary
- strip `code` from `get_reservations` endpoint
- add regression test ensuring returned reservations have no `code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840142a0f8483249c012a8fe484d32b