### PR TITLE
Add width limit to code inputs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
         </select>
 
         <label>Code (4 chiffres)</label>
-        <input type="text" id="code" pattern="\d{4}" required>
+        <input type="text" id="code" pattern="\d{4}" required maxlength="4" inputmode="numeric" style="max-width:8em;">
 
         <button type="submit">Réserver</button>
     </form>
@@ -136,7 +136,7 @@
 <div class="modal" id="delete-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); justify-content:center; align-items:center; z-index:1000;">
     <div class="modal-content" style="background:white; padding:20px; border-radius:10px; text-align:center;">
         <p>Entrer le code pour supprimer la réservation :</p>
-        <input type="text" id="delete-code" style="padding:10px; width:80%; margin-top:10px;" />
+        <input type="text" id="delete-code" maxlength="4" inputmode="numeric" style="padding:10px; width:80%; margin-top:10px; max-width:8em;" />
         <div id="delete-error" style="color:red; margin-top:10px; display:none;">❌ Code incorrect</div>
         <button onclick="confirmDelete()" style="margin-top:15px;">Confirmer</button>
         <button onclick="cancelDelete()" style="margin-top:10px;">Annuler</button>


### PR DESCRIPTION
## Summary
- restrict `#code` and `#delete-code` fields to max 8em
- set `maxlength="4"` and `inputmode="numeric"` for numeric codes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684014d74270832489b847be6aa4a21d