### PR TITLE
Configure calendar height and scrolling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
             margin: 0;
             padding: 0;
             background: #f4f4f4;
+            overflow-y: auto;
             transition: background 0.3s, color 0.3s;
         }
         body.dark-mode {
@@ -76,6 +77,10 @@
         }
         #calendar {
             margin-top: 2em;
+        }
+        #calendar .fc-scroller,
+        #calendar .fc-timegrid-body {
+            overflow: visible !important;
         }
         @media screen and (max-width: 600px) {
             body { font-size: 16px; }
@@ -204,6 +209,8 @@ document.addEventListener("DOMContentLoaded", () => {
         locale: 'fr',
         slotMinTime: '07:00:00',
         slotMaxTime: '23:00:00',
+        height: 'auto',
+        expandRows: true,
         events: '/get_reservations',
         eventDidMount: function(info) {
             const now = new Date();


### PR DESCRIPTION
## Summary
- ensure page scrolls by default
- make calendar body scroll-free
- let FullCalendar expand to show all time slots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840156391e48324b7a031cee27ba0cc