### PR TITLE
Fix admin code entry and show confirmation

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,17 +70,30 @@ def reserver():
     if total_journalier + int(data["tournees"]) > 3:
         return jsonify({"status": "error", "message": "❌ Limite de 3 tournées par machine et par jour atteinte."}), 400
 
-    reservations.append({
+    reservation_record = {
         "title": f"Chambre {data['chambre']}",
         "start": start,
         "end": end,
         "machine": data["machine"],
         "code": data["code"]
-    })
+    }
+    reservations.append(reservation_record)
 
     save_reservations(reservations)
 
-    return jsonify({"status": "ok"})
+    response_payload = {
+        "status": "ok",
+        "reservation": {
+            "chambre": data["chambre"],
+            "date": data["date"],
+            "start": start,
+            "end": end,
+            "machine": data["machine"],
+            "code": data["code"]
+        }
+    }
+
+    return jsonify(response_payload)
 
 @app.route("/get_reservations", methods=["GET"])
 def get_reservations():

--- a/templates/index.html
+++ b/templates/index.html
@@ -157,10 +157,19 @@
 <div class="modal" id="delete-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); justify-content:center; align-items:center; z-index:1000;">
     <div class="modal-content" style="background:white; padding:20px; border-radius:10px; text-align:center;">
         <p>Entrer le code pour supprimer la réservation :</p>
-        <input type="text" id="delete-code" maxlength="4" inputmode="numeric" style="padding:10px; width:80%; margin-top:10px; max-width:8em;" />
+        <input type="text" id="delete-code" maxlength="5" inputmode="numeric" style="padding:10px; width:80%; margin-top:10px; max-width:8em;" />
         <div id="delete-error" style="color:red; margin-top:10px; display:none;">❌ Code incorrect</div>
         <button onclick="confirmDelete()" style="margin-top:15px;">Confirmer</button>
         <button onclick="cancelDelete()" style="margin-top:10px;">Annuler</button>
+    </div>
+</div>
+
+<div class="modal" id="confirm-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); justify-content:center; align-items:center; z-index:1000;">
+    <div class="modal-content" style="background:white; padding:20px; border-radius:10px; text-align:center;">
+        <h3>Réservation confirmée ✅</h3>
+        <div id="receipt-details" style="margin:15px 0;"></div>
+        <button onclick="printReceipt()">Imprimer le reçu</button>
+        <button onclick="closeConfirm()" style="margin-top:10px;">Fermer</button>
     </div>
 </div>
 
@@ -185,6 +194,25 @@ function confirmDelete() {
 function cancelDelete() {
     document.getElementById("delete-modal").style.display = "none";
     selectedEvent = null;
+}
+
+function closeConfirm() {
+    document.getElementById("confirm-modal").style.display = "none";
+    location.reload();
+}
+
+function printReceipt() {
+    const receipt = document.getElementById("receipt-details").innerHTML;
+    const win = window.open("", "_blank");
+    win.document.write("<html><head><title>Reçu</title></head><body>" + receipt + "</body></html>");
+    win.document.close();
+    win.print();
+}
+
+function showConfirmation(reservation) {
+    const details = `Chambre ${reservation.chambre}<br>Date : ${reservation.date}<br>Début : ${reservation.start.split('T')[1]}<br>Fin : ${reservation.end.split('T')[1]}<br>Code : ${reservation.code}`;
+    document.getElementById("receipt-details").innerHTML = details;
+    document.getElementById("confirm-modal").style.display = "flex";
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -285,7 +313,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }).then(async res => {
             const data = await res.json();
             if (res.ok) {
-                location.reload();
+                showConfirmation(data.reservation);
             } else {
                 alert(data.message || "❌ Erreur lors de la réservation.");
             }

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -35,7 +35,10 @@ def test_successful_reservation(client):
     }
     response = client.post("/reserver", json=payload)
     assert response.status_code == 200
-    assert response.get_json()["status"] == "ok"
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["reservation"]["start"] == "2025-01-01T08:00"
+    assert data["reservation"]["end"] == "2025-01-01T09:00"
     reservations = load_reservations()
     assert len(reservations) == 1
     assert reservations[0]["start"] == "2025-01-01T08:00"


### PR DESCRIPTION
## Summary
- allow 5 characters in delete code field
- return reservation details from `/reserver`
- show confirmation modal with printable receipt
- update tests for new response

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840113f5b2083248551fc4f18038697