### PR TITLE
Include code on receipts

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,6 +153,7 @@ def receipt(res_id: int):
         pdf.cell(0, 6, f"Machine : {r['machine']}", ln=True)
         pdf.cell(0, 6, f"Début : {r['start'].replace('T', ' ')}", ln=True)
         pdf.cell(0, 6, f"Fin : {r['end'].replace('T', ' ')}", ln=True)
+        pdf.cell(0, 6, f"Code : {r['code']}", ln=True)
         pdf.ln(4)
         pdf.set_font("Arial", "I", 8)
         if created_dt:

--- a/templates/index.html
+++ b/templates/index.html
@@ -169,7 +169,7 @@
         <h3>Réservation confirmée ✅</h3>
         <div id="receipt-details" style="margin:15px 0;"></div>
         <a id="receipt-open" href="#" target="_blank" style="display:block;margin-bottom:10px;">Voir le reçu</a>
-        <a id="receipt-download" href="#" style="display:block;margin-bottom:10px;">Télécharger le PDF</a>
+        <a id="receipt-download" href="#" style="display:block;margin-bottom:10px;">Télécharger le reçu</a>
         <button onclick="printReceipt()">Imprimer le reçu</button>
         <button onclick="closeConfirm()" style="margin-top:10px;">Fermer</button>
     </div>

--- a/templates/receipt.html
+++ b/templates/receipt.html
@@ -16,6 +16,7 @@
     <div class="details">Machine : {{ reservation.machine }}</div>
     <div class="details">Début : {{ reservation.start.replace('T', ' ') }}</div>
     <div class="details">Fin : {{ reservation.end.replace('T', ' ') }}</div>
+    <div class="details">Code : {{ reservation.code }}</div>
     {% if created %}
     <footer>{{ hotel_name }} - réservation effectuée le {{ created.strftime('%Y-%m-%d %H:%M') }}</footer>
     {% else %}

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -163,3 +163,4 @@ def test_receipt_route(client):
     assert "lave-linge" in text
     assert "Chambre 4" in text
     assert "réservation effectuée" in text
+    assert "1234" in text


### PR DESCRIPTION
## Summary
- show the reservation code on both HTML and PDF receipts
- rename the download link to "Télécharger le reçu"
- test that the reservation code appears on the receipt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684021994ab48324b3c7dec264859b9f