### PR TITLE
Implement auto-print receipt option

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ def receipt(res_id: int):
     r = reservations[res_id]
     created_str = r.get("created")
     created_dt = datetime.fromisoformat(created_str) if created_str else None
+    auto_print = request.args.get("auto_print") == "1"
     if request.args.get("pdf") == "1":
         pdf = FPDF(unit="mm", format=(80, 120))
         pdf.add_page()
@@ -172,6 +173,7 @@ def receipt(res_id: int):
         hotel_name="Hotel Grill",
         generated=datetime.now(),
         created=created_dt,
+        auto_print=auto_print,
     )
 
 if __name__ == "__main__":

--- a/static/app.js
+++ b/static/app.js
@@ -24,11 +24,8 @@ function closeConfirm() {
 }
 
 function printReceipt() {
-    const receipt = document.getElementById("receipt-details").innerHTML;
-    const win = window.open("", "_blank");
-    win.document.write("<html><head><title>Reçu</title></head><body>" + receipt + "</body></html>");
-    win.document.close();
-    win.print();
+    const href = document.getElementById("receipt-open").href;
+    window.open(href + "?auto_print=1", "_blank");
 }
 
 function showConfirmation(reservation) {

--- a/templates/receipt.html
+++ b/templates/receipt.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <title>Reçu</title>
     <style>
-        body { width: 8cm; margin: 0 auto; font-family: Arial, sans-serif; }
-        h1 { font-size: 1.2em; text-align: center; margin-bottom: 10px; }
-        .details { font-size: 0.9em; margin: 3px 0; }
-        footer { font-size: 0.7em; font-style: italic; text-align: center; margin-top: 15px; }
+        body { width: 80mm; margin: 0 auto; font-family: Arial, sans-serif; font-size: 11pt; }
+        h1 { font-size: 14pt; text-align: center; margin: 5px 0 10px; }
+        .details { font-size: 11pt; margin: 2px 0; }
+        footer { font-size: 8pt; font-style: italic; text-align: center; margin-top: 10px; }
     </style>
 </head>
 <body>
@@ -21,6 +21,9 @@
     <footer>{{ hotel_name }} - réservation effectuée le {{ created.strftime('%Y-%m-%d %H:%M') }}</footer>
     {% else %}
     <footer>{{ hotel_name }}</footer>
+    {% endif %}
+    {% if auto_print %}
+    <script>window.print();</script>
     {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add optional `auto_print` query param to `/receipt` endpoint
- tweak receipt template fonts and auto print logic
- open receipt URL in print dialog from JS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d33155d88324a25ab90fed6280a9