### PR TITLE
Add instructions headings

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -35,6 +35,14 @@ body.dark-mode .container {
 }
 .instructions { background: #f8f8f8; padding: 1em; border-radius: 10px; margin-bottom: 1em; }
 .instructions li { margin: 0.5em 0; }
+.instructions-title {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+body.dark-mode .instructions-title {
+    color: #f0f0f0;
+}
 body.dark-mode .instructions { background: #2a2a2a; }
 .instructions.cancel { background: #fff4e5; }
 body.dark-mode .instructions.cancel { background: #5a3a2a; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,7 @@
 
 <div class="container">
     <div class="instructions">
+        <h3 class="instructions-title">Comment réserver ?</h3>
         <ul>
             <li>1️⃣ Choisissez <strong>chambre</strong>, <strong>date</strong> et <strong>heure</strong>.</li>
             <li>2️⃣ Sélectionnez la <strong>machine</strong>.</li>
@@ -29,6 +30,7 @@
         </ul>
     </div>
     <div class="instructions cancel">
+        <h3 class="instructions-title">Comment annuler ?</h3>
         <ul>
             <li>1️⃣ Cliquez sur la réservation dans le calendrier.</li>
             <li>2️⃣ Saisissez votre <strong>code</strong> de réservation.</li>


### PR DESCRIPTION
## Summary
- add headings for reservation and cancellation instructions
- style new instruction titles for light and dark modes

## Testing
- `pytest -q`
- `curl -s http://127.0.0.1:5000 | head` (manual check of layout)

------
https://chatgpt.com/codex/tasks/task_e_6843101de2a88324b359054cff327f8a