### PR TITLE
Allow Gunicorn port override

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --bind 0.0.0.0:${PORT:-8080}


### PR DESCRIPTION
## Summary
- bind Gunicorn in `Procfile` to `$PORT` for Fly.io compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684312d40e1083249523fbda0d8889fe