### PR TITLE
Update README for Fly.io deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --bind 0.0.0.0:${PORT:-8080}

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Deux variables d'environnement permettent d'ajuster le comportement de l'applica
 
 ## Exécution en production
 
-Pour un environnement de production, il est recommandé d'utiliser Gunicorn :
+Pour un environnement de production, il est recommandé d'utiliser Gunicorn et de lier l'application au port fourni par la plateforme. Cela permet un fonctionnement identique sur Fly.io, Railway ou tout autre hébergeur définissant la variable `PORT` :
 
 ```bash
-gunicorn app:app
+gunicorn app:app --bind 0.0.0.0:${PORT:-8080}
 ```
 
-Le `Procfile` fourni contient cette commande afin de faciliter le déploiement sur des plateformes comme Heroku.
+Le `Procfile` inclus utilise cette commande afin de faciliter le déploiement sur différentes plateformes.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- clarify production gunicorn command to bind the PORT environment variable for platforms such as Fly.io and Railway

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684312d40e1083249523fbda0d8889fe