### PR TITLE
Retirer reservations.json et documenter sa création

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -30,6 +30,12 @@
    pip install -r requirements.txt
    ```
 
+4. عند التثبيت لأول مرة، أنشئ ملف `reservations.json` فارغ في جذر المشروع:
+
+   ```bash
+   echo "[]" > reservations.json
+   ```
+
 ## التشغيل محليا
 
 اشغل ملف `app.py` مباشرة لبدء الخادم المحلي:

--- a/README.en.md
+++ b/README.en.md
@@ -31,6 +31,12 @@ This application manages online reservations for a laundry's machines. It is wri
    pip install -r requirements.txt
    ```
 
+4. When installing for the first time, create an empty `reservations.json` file at the project root:
+
+   ```bash
+   echo "[]" > reservations.json
+   ```
+
 ## Running locally
 
 Execute the `app.py` file directly to start the local server:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Cette application permet de gérer la réservation en ligne des machines d'une b
    pip install -r requirements.txt
    ```
 
+4. Lors de la première installation, créez un fichier `reservations.json` vide à la racine du projet :
+
+   ```bash
+   echo "[]" > reservations.json
+   ```
+
 ## Lancement en local
 
 Exécutez directement le fichier `app.py` pour lancer le serveur local :

--- a/reservations.json
+++ b/reservations.json
@@ -1,1 +1,0 @@
-[{"title": "Chambre 1", "start": "2025-05-20T10:00", "end": "2025-05-20T11:00", "machine": "lave-linge", "code": "1234"}]


### PR DESCRIPTION
## Summary
- retire `reservations.json` du dépôt
- documente sa création lors de la première installation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685521cc40e483249adbf25aff2a782d